### PR TITLE
Avoid code bloat in Display impl for Operation

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -27,7 +27,7 @@ impl Display for Operator {
             Operator::Add => "Added to\n",
             Operator::Subtract => "Minus\n",
         };
-        write!(f, "{}", output)
+        f.write_str(output)
     }
 }
 


### PR DESCRIPTION
Although convenient, `write!` macro forwards to `format_args!`, which generates a lot of code. Calling method directly is faster and doesn't bloat resulting binary that much.